### PR TITLE
Guess the controller without input or changing device

### DIFF
--- a/input_helper/input_helper.gd
+++ b/input_helper/input_helper.gd
@@ -69,3 +69,10 @@ func get_button_index(action_name: String) -> int:
 			return input.button_index
 	
 	return -1
+
+func guess_controller() -> String:
+	var connected_joypads = Input.get_connected_joypads()
+	if connected_joypads.size() == 0:
+		return DEVICE_KEYBOARD
+	else:
+		return get_simplified_device_name(Input.get_joy_name(0))


### PR DESCRIPTION
Added function to guess the controller without input or changing device. This is a method I use in my game when firing it up for the first time and asking the user what input prompts they would like to see. Can be useful in such scenarios.