### PR TITLE
add detection of a wireless X360 controller

### DIFF
--- a/input_helper/input_helper.gd
+++ b/input_helper/input_helper.gd
@@ -38,7 +38,7 @@ func _input(event: InputEvent) -> void:
 
 func get_simplified_device_name(raw_name: String) -> String:
 	match raw_name:
-		"XInput Gamepad", "Xbox Series Controller":
+		"XInput Gamepad", "Xbox Series Controller", "Xbox 360 Wireless Receiver":
 			return DEVICE_XBOX_CONTROLLER
 		
 		"PS5 Controller", "PS4 Controller", "PS3 Controller", "PS2 Controller":


### PR DESCRIPTION
I've noticed my wireless Xbox 360 controller was not being properly detected (I'd get generic when trying the examples).  
This patch should fix it.  
Let me know if I missed any check outside of `get_simplified_device_name()`.