### PR TITLE
Change color from #fff to Color.WHITE

### DIFF
--- a/addons/input_helper/examples/device_tester.gd
+++ b/addons/input_helper/examples/device_tester.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 
 
 func write_to_log(label: String, device: String, device_index: int) -> void:
-	var color = "#fff"
+	var color = Color.WHITE
 	match device:
 		InputHelper.DEVICE_KEYBOARD:
 			color = Color.YELLOW


### PR DESCRIPTION
If the device is generic, `write_to_log()` will cause an error due to calling `color.to_html()` on a String.