### PR TITLE
Adjust get_action_key() function for physical keys

### DIFF
--- a/addons/input_helper/input_helper.gd
+++ b/addons/input_helper/input_helper.gd
@@ -99,7 +99,8 @@ func is_valid_key(key: String) -> bool:
 func get_action_key(action: String) -> String:
 	for event in InputMap.get_action_list(action):
 		if event is InputEventKey:
-			return event.as_text()
+			var scancode = event.physical_scancode if event.physical_scancode != 0 else event.scancode
+			return OS.get_scancode_string(scancode)
 	return ""
 
 

--- a/addons/input_helper/input_helper.gd
+++ b/addons/input_helper/input_helper.gd
@@ -99,7 +99,7 @@ func is_valid_key(key: String) -> bool:
 func get_action_key(action: String) -> String:
 	for event in InputMap.get_action_list(action):
 		if event is InputEventKey:
-			var scancode = event.physical_scancode if event.physical_scancode != 0 else event.scancode
+			var scancode = OS.keyboard_get_scancode_from_physical(physical_scancode) if event.physical_scancode != 0 else event.scancode
 			return OS.get_scancode_string(scancode)
 	return ""
 


### PR DESCRIPTION
In the old implementation `event.as_text()` returns `Q (Physical)` if a physical binding is used and just `Q` if a regular binding is used.

For regular bindings this new implementation works the same as the old one (returns `Q`).

For physical bindings this implementation returns a correct key name depending on the user's current keyboard layout (for AZERTY keyboards returns `A`, for DVORAK keyboards returns `D`, etc), without the additional '(Physical)' word.