### PR TITLE
Add additional Xbox controller names used in Linux

### DIFF
--- a/addons/input_helper/input_helper.gd
+++ b/addons/input_helper/input_helper.gd
@@ -55,7 +55,8 @@ func _input(event: InputEvent) -> void:
 # Convert a Godot device identifier to a simplified string
 func get_simplified_device_name(raw_name: String) -> String:
 	match raw_name:
-		"XInput Gamepad", "Xbox Series Controller":
+		"XInput Gamepad", "Xbox Series Controller", "Xbox 360 Controller", \
+		"Xbox One Controller":
 			return DEVICE_XBOX_CONTROLLER
 		
 		"Sony DualSense", "PS5 Controller", "PS4 Controller", \


### PR DESCRIPTION
Trying this addon in Godot v4.1.0 on my laptop (running Pop!_OS), I found that my Xbox 360 wired controller reported as `"Xbox 360 Controller"` and my Xbox One controller reported as `"Xbox One Controller"`.

This PR just adds those names so they can be detected officially as Xbox controllers.

Thanks for making this addon! Very helpful and exactly what I needed.