### PR TITLE
Fix bug with detecting if a controller is used when moving a joystick to a negative axis.

### DIFF
--- a/addons/input_helper/input_helper.gd
+++ b/addons/input_helper/input_helper.gd
@@ -39,7 +39,7 @@ func _input(event: InputEvent) -> void:
 
 	# Did we just use a gamepad?
 	elif event is InputEventJoypadButton \
-		or (event is InputEventJoypadMotion and event.axis_value > deadzone):
+		or (event is InputEventJoypadMotion and abs(event.axis_value) > deadzone):
 		next_device = get_simplified_device_name(Input.get_joy_name(event.device))
 		next_device_index = event.device
 


### PR DESCRIPTION
The problem was the addon wasn't detecting I changed to using a controller when moving the joystick to the left, because its `axis_value` was negative and it checks if it's higher than the deadzone. Easy fix though, just taking it's absolute value.