### PR TITLE
Fix unexpected behavior on replace_joypad_input_at_index

### DIFF
--- a/addons/input_helper/input_helper.gd
+++ b/addons/input_helper/input_helper.gd
@@ -336,7 +336,12 @@ func replace_joypad_input_for_action(action: String, current_input: InputEvent, 
 ## Replace a button, given its index
 func replace_joypad_input_at_index(action: String, index: int, input: InputEvent, swap_if_taken: bool = true) -> Error:
 	var inputs: Array[InputEvent] = get_joypad_inputs_for_action(action)
-	var replacing_input = InputEventJoypadButton.new() if (inputs.is_empty() or inputs.size() <= index) else inputs[index]
+	var replacing_input
+	if inputs.is_empty() or inputs.size() <= index:
+		replacing_input = InputEventJoypadButton.new()
+		replacing_input.button_index = JOY_BUTTON_INVALID
+	else:
+		replacing_input = inputs[index]
 	return _update_joypad_input_for_action(action, input, swap_if_taken, replacing_input)
 
 


### PR DESCRIPTION
Implements the proposed solution for #36 

This matches the behavior from replace_keyboard_input_at_index in the snippet below, where the keycode [defaults to an invalid value](https://docs.godotengine.org/en/stable/classes/class_inputeventkey.html#class-inputeventkey-property-keycode)

`var replacing_input = InputEventKey.new() if (inputs.is_empty() or inputs.size() <= index) else inputs[index]`