### PR TITLE
Add recognition of "Xbox Wireless Controller" controller

### DIFF
--- a/addons/input_helper/input_helper.gd
+++ b/addons/input_helper/input_helper.gd
@@ -63,7 +63,7 @@ func _input(event: InputEvent) -> void:
 # Convert a Godot device identifier to a simplified string
 func get_simplified_device_name(raw_name: String) -> String:
 	match raw_name:
-		"XInput Gamepad", "Xbox Series Controller", "Xbox 360 Controller", \
+		"XInput Gamepad", "Xbox Series Controller", "Xbox 360 Controller", "Xbox Wireless Controller", \
 		"Xbox One Controller":
 			return DEVICE_XBOX_CONTROLLER
 


### PR DESCRIPTION
## Issue
I found that my Xbox Controller was wrongly set as "generic" controller with the Input Helper (on OSX). I don't really know why my controller does not fit existing labels added in the Input Helper, but found in Godot documentation that the engine followed the naming of the [SDL database](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L1100). Using `Input.get_joy_name(0)` gave me "Xbox Wireless Controller".

## Changes
Add the "Xbox Wireless Controller" among the recognized names for the Xbox controllers.