### PR TITLE
Fix xbox controller is recognized as generic

### DIFF
--- a/addons/input_helper/input_helper.gd
+++ b/addons/input_helper/input_helper.gd
@@ -64,7 +64,7 @@ func _input(event: InputEvent) -> void:
 func get_simplified_device_name(raw_name: String) -> String:
 	match raw_name:
 		"XInput Gamepad", "Xbox Series Controller", "Xbox 360 Controller", \
-		"Xbox One Controller":
+		"Xbox One Controller", "Xbox Wireless Controller":
 			return DEVICE_XBOX_CONTROLLER
 
 		"Sony DualSense", "PS5 Controller", "PS4 Controller", \


### PR DESCRIPTION
My xbox controller is recognized as generic, and this PR fixes it.