### PR TITLE
Add mapping for steam deck controller

### DIFF
--- a/addons/input_helper/input_helper.gd
+++ b/addons/input_helper/input_helper.gd
@@ -18,7 +18,7 @@ const DEVICE_GENERIC = "generic"
 const XBOX_BUTTON_LABELS = ["A", "B", "X", "Y", "Back", "Home", "Menu", "Left Stick", "Right Stick", "Left Shoulder", "Right Shoulder", "Up", "Down", "Left", "Right", "Share"]
 const SWITCH_BUTTON_LABELS = ["B", "A", "Y", "X", "-", "", "+", "Left Stick", "Right Stick", "Left Shoulder", "Right Shoulder", "Up", "Down", "Left", "Right", "Capture"]
 const PLAYSTATION_BUTTON_LABELS = ["Cross", "Circle", "Square", "Triangle", "Select", "PS", "Options", "L3", "R3", "L1", "R1", "Up", "Down", "Left", "Right", "Microphone"]
-
+const STEAMDECK_BUTTON_LABELS = ["A", "B", "X", "Y", "Select", "?", "Start", "Left Stick", "Right Stick", "Left Shoulder", "Right Shoulder", "Up", "Down", "Left", "Right"]
 
 @onready var device: String = guess_device_name()
 @onready var device_index: int = 0 if has_joypad() else -1
@@ -70,6 +70,9 @@ func get_simplified_device_name(raw_name: String) -> String:
 		"Sony DualSense", "PS5 Controller", "PS4 Controller", \
 		"Nacon Revolution Unlimited Pro Controller":
 			return DEVICE_PLAYSTATION_CONTROLLER
+
+		"Steam Virtual Gamepad":
+			return DEVICE_STEAMDECK_CONTROLLER
 
 		"Switch":
 			return DEVICE_SWITCH_CONTROLLER
@@ -165,6 +168,8 @@ func get_label_for_input(input: InputEvent) -> String:
 				return "%s Button" % SWITCH_BUTTON_LABELS[input.button_index]
 			DEVICE_PLAYSTATION_CONTROLLER:
 				return "%s Button" % PLAYSTATION_BUTTON_LABELS[input.button_index]
+			DEVICE_STEAMDECK_CONTROLLER:
+				return "%s Button" % STEAMDECK_BUTTON_LABELS[input.button_index]
 
 	elif input is InputEventJoypadMotion:
 		var motion: InputEventJoypadMotion = input as InputEventJoypadMotion


### PR DESCRIPTION
Add steam deck controller mapping

Some remarks:
- the button 5 is not identified (maybe steam button)
- the back triggers L4/L5/R4/R5 are not recognized (maybe we should use steam deck SDK to use them)
- L2 and R2 are not recognized as buttons but axis (Axis 4 and 5)
- there seem to be no vibration