### PR TITLE
fix: add missing steamdeck const

### DIFF
--- a/addons/input_helper/input_helper.gd
+++ b/addons/input_helper/input_helper.gd
@@ -13,6 +13,7 @@ const DEVICE_SWITCH_CONTROLLER = "switch"
 const DEVICE_SWITCH_JOYCON_LEFT_CONTROLLER = "switch_left_joycon"
 const DEVICE_SWITCH_JOYCON_RIGHT_CONTROLLER = "switch_right_joycon"
 const DEVICE_PLAYSTATION_CONTROLLER = "playstation"
+const DEVICE_STEAMDECK_CONTROLLER = "steamdeck"
 const DEVICE_GENERIC = "generic"
 
 const XBOX_BUTTON_LABELS = ["A", "B", "X", "Y", "Back", "Home", "Menu", "Left Stick", "Right Stick", "Left Shoulder", "Right Shoulder", "Up", "Down", "Left", "Right", "Share"]


### PR DESCRIPTION
I love the steamdeck support, and this addon in general, thanks for all the effort and a great tool!

Here's a quick fix i needed to get input helper compiling again, adding a constant that the code was expecting - maybe it got lost in a commit somewhere?