### PR TITLE
Add missing LastKnownJoypadIndex to C#

### DIFF
--- a/addons/input_helper/InputHelper.cs
+++ b/addons/input_helper/InputHelper.cs
@@ -68,6 +68,12 @@ namespace NathanHoad
     }
 
 
+    public static string LastKnownJoypadIndex
+    {
+      get => (string)Instance.Get("last_known_joypad_index");
+    }
+
+
     public static float Deadzone
     {
       get => (float)Instance.Get("deadzone");


### PR DESCRIPTION
This adds `LastKnownJoypadIndex` that was missing from the C# wrapper.